### PR TITLE
Make suggested comics table more readable and add cub policy

### DIFF
--- a/src/pages/SuggestComic.vue
+++ b/src/pages/SuggestComic.vue
@@ -22,6 +22,9 @@
         <li>
           The comic will not be accepted if it has censoring bars, dots, etc.
         </li>
+        <li>
+          The comic will not be accepted if it has cub content.
+        </li>
       </ul>
 
       <Form :buttonText="'Submit suggestion'"
@@ -58,7 +61,7 @@
         </p>
       </Form>
 
-      <div id="rejectedComics" class="margin-top-32 scrolling-table-container">
+      <div id="rejectedComics" class="margin-top-32">
         <h2>Previously rejected comics</h2>
         <table class="yTable mt-8" v-if="rejectedComics.length > 0">
           <thead>

--- a/src/scss/general.scss
+++ b/src/scss/general.scss
@@ -103,18 +103,6 @@ select {
   position: relative;
 }
 
-.scrolling-table-container {
-  overflow-x: auto;
-  max-width: 100%;
-  td, th {
-    word-break: normal;
-    word-wrap: none;
-  }
-  table {
-    white-space: nowrap;
-  }
-}
-
 .no-margin-bot {
   p, select, button {
     margin-bottom: 0 !important;
@@ -321,6 +309,9 @@ select {
 }
 
 .yTable {
+  table-layout: fixed;
+  width: 100%;
+  white-space: normal;
   border-collapse: collapse;
   p {
     font-size: 1rem;


### PR DESCRIPTION
* Remove styling (as far as I am aware, `scrolling-table-container` was only used once).

It should be noted that the table becomes kind of cramped on mobile displays. This could be solved by adding a min width to the table, an overflow to the containing div (as you had before), and some kind of element to hint that the table can scroll sideways. Another alternative could be adding a positioned border radius to the left and right headers that suggests scroll-ability.

This commit makes it so that extra long titles/artists/reasons don't make the table difficult to read. It also documents the apparent cub policy.